### PR TITLE
Issue 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The `assign` command creates or updates a submission_request object on Udacity's
 #### Exiting `assign`
 
 You can exit the script in two ways:
-- Press `ESC` to exit without deleting your submission_request object on the server. You will stay in the queues you are in for as long as the submission_request persists (up to an hour).
+- Press `ESC` to exit without deleting your submission_request object on the server. The submission request will be refreshed so that you will stay in the queues you are in for an hour.
 - Press `CTRL-C` to exit _and_ delete the submission_request on the server. This means that you leave all the queues that you are in.
 
 #### Updating `assign`

--- a/lib/urcli-assign.js
+++ b/lib/urcli-assign.js
@@ -316,10 +316,12 @@ rl.on('SIGINT', () => {
   })
 })
 
-// Suspend on ESC without deleting the submission_request.
+// Suspend on ESC and refresh the submission_request rather than deleting it.
 process.stdin.on('data', key => {
   if (key == '\u001b') {
+    apiCall('refresh', requestId)
     console.log(chalk.green('Exited without deleting the submission_request...'))
+    console.log(chalk.green('The current submission_request will expire in an hour.'))
     process.exit(0)
   }
 })


### PR DESCRIPTION
Refreshes the submission_request object when the assign script is suspended. This is done since the only reason you would suspend is if you don't want to delete the object, and you can assume that the longer the lifetime of the object the better.