### PR TITLE
Average earnings

### DIFF
--- a/lib/urcli-money.js
+++ b/lib/urcli-money.js
@@ -111,7 +111,19 @@ function validateDate (date) {
 
 class Report {
   constructor (reviews, period) {
-    this.period = period
+    this.startDate = period[0].format('YYYY-MM-DD')
+    this.endDate = period[1].format('YYYY-MM-DD')
+    // We need to check if we're using the default startDate, so that we can
+    // find the earliest date a submission was assigned. This date is needed to
+    // get the correct number of days of the period, so we can calculate the
+    // average daily earnings for the period.
+    if (this.startDate === '2014-01-01') {
+      const firstDate = reviews
+        .map(review => moment(review.assigned_at)) // returns date of review
+        .map(date => date.valueOf()) // returns date in Unix Time (milliseconds from 1970)
+        .reduce((acc, val) => acc < val ? acc : val) // returns the smallest number
+      this.startDate = moment(firstDate).format('YYYY-MM-DD')
+    }
     this.reviews = reviews
     this.projects = {}
     this.totalEarned = 0
@@ -154,11 +166,7 @@ class Report {
   }
 
   print () {
-    let startDate = moment(this.period[0]).format('YYYY-MM-DD')
-    let endDate = moment(this.period[1]).format('YYYY-MM-DD')
-    let numberOfDays = moment(endDate).diff(startDate, 'days')
-
-    console.log(chalk.blue(`\nEarnings Report for ${startDate} to ${endDate}:`))
+    console.log(chalk.blue(`\nEarnings Report for ${this.startDate} to ${this.endDate}:`))
     console.log('=============================================')
     console.log(chalk.bgBlack.white(`Total Projects Assigned: ${this.totalAssigned}`))
 
@@ -182,6 +190,7 @@ class Report {
     console.log(chalk.white(`Total Earned: ${currencyFormatter.format(this.totalEarned, {code: 'USD'})}`))
 
     // Only print Daily Average if we have more than one day to average
+    let numberOfDays = moment(this.endDate).diff(this.startDate, 'days')
     if (numberOfDays > 1) {
         console.log(chalk.white(`Daily Average: ${currencyFormatter.format(this.totalEarned/numberOfDays, {code: 'USD'})}`))
     }

--- a/lib/urcli-money.js
+++ b/lib/urcli-money.js
@@ -173,7 +173,7 @@ class Report {
     }
 
     console.log(chalk.white(`Total Earned: ${currencyFormatter.format(this.totalEarned, {code: 'USD'})}`))
-    console.log(chalk.white(`Daily Averaged Earnings : ${currencyFormatter.format(this.totalEarned/numberDays, {code: 'USD'})}`))
+    console.log(chalk.white(`Daily Average: ${currencyFormatter.format(this.totalEarned/numberDays, {code: 'USD'})}`))
     console.log('=============================================')
   }
 }

--- a/lib/urcli-money.js
+++ b/lib/urcli-money.js
@@ -75,7 +75,7 @@ function definePeriods () {
       const yearAndMonth = arg < 9 ? `${year}-0${arg}` : `${year}-${arg}`
       let start = moment(yearAndMonth).utc()
       // Check if month asked is the current month
-      if (arg === String(month)) {
+      if (arg === month.toString()) {
          // Make the last day to query as being today
          let end = moment.utc().endOf('day')
          periods.push([start, end])

--- a/lib/urcli-money.js
+++ b/lib/urcli-money.js
@@ -140,6 +140,7 @@ class Report {
   print () {
     let startDate = moment(this.period[0]).format('YYYY-MM-DD')
     let endDate = moment(this.period[1]).format('YYYY-MM-DD')
+    let numberDays = moment(endDate).diff(startDate, 'days')
 
     console.log(chalk.blue(`\nEarnings Report for ${startDate} to ${endDate}:`))
     console.log('=============================================')
@@ -163,6 +164,7 @@ class Report {
     }
 
     console.log(chalk.white(`Total Earned: ${currencyFormatter.format(this.totalEarned, {code: 'USD'})}`))
+    console.log(chalk.white(`Daily Averaged Earnings : ${currencyFormatter.format(this.totalEarned/numberDays, {code: 'USD'})}`))
     console.log('=============================================')
   }
 }

--- a/lib/urcli-money.js
+++ b/lib/urcli-money.js
@@ -173,7 +173,11 @@ class Report {
     }
 
     console.log(chalk.white(`Total Earned: ${currencyFormatter.format(this.totalEarned, {code: 'USD'})}`))
-    console.log(chalk.white(`Daily Average: ${currencyFormatter.format(this.totalEarned/numberDays, {code: 'USD'})}`))
+
+    //Only print Daily Average if thea rgument is not 'today'
+    if (cli.args != 'today') {
+        console.log(chalk.white(`Daily Average: ${currencyFormatter.format(this.totalEarned/numberDays, {code: 'USD'})}`))
+    }
     console.log('=============================================')
   }
 }

--- a/lib/urcli-money.js
+++ b/lib/urcli-money.js
@@ -175,7 +175,7 @@ class Report {
     console.log(chalk.white(`Total Earned: ${currencyFormatter.format(this.totalEarned, {code: 'USD'})}`))
 
     //Only print Daily Average if thea rgument is not 'today'
-    if (cli.args != 'today') {
+    if (!(cli.args == 'today' || cli.args == 'yesterday')) {
         console.log(chalk.white(`Daily Average: ${currencyFormatter.format(this.totalEarned/numberDays, {code: 'USD'})}`))
     }
     console.log('=============================================')

--- a/lib/urcli-money.js
+++ b/lib/urcli-money.js
@@ -66,8 +66,17 @@ function definePeriods () {
       }
       const yearAndMonth = arg < 9 ? `${year}-0${arg}` : `${year}-${arg}`
       let start = moment(yearAndMonth).utc()
-      let end = moment(yearAndMonth).utc().add(1, 'M')
-      periods.push([start, end])
+      // Check if month asked is the current month
+      let currentMonth = moment.utc().add(1, 'M').month()
+      if (currentMonth == arg) {
+         // Make the last day to query as being today
+         let end = moment.utc()
+         periods.push([start, end])
+      } else {
+         // Otherwise, pick the first midnight of the first day of next month.
+         let end = moment(yearAndMonth).utc().add(1, 'M')
+         periods.push([start, end])
+      }
     }  else if (arg === 'today') {
       let start = moment.utc().startOf('day')
       let end = moment.utc().endOf('day')

--- a/lib/urcli-money.js
+++ b/lib/urcli-money.js
@@ -56,8 +56,16 @@ function definePeriods () {
     // Testing what arguments we got from the user.
     if (matchYearMonth.test(arg)) {
       let start = moment(arg).utc()
-      let end = moment(arg).utc().add(1, 'M')
-      periods.push([start, end])
+      // Check if month asked is the current month
+      if (arg === moment.utc().format('YYYY-MM')) {
+         // Make the last day to query as being today
+         let end = moment.utc().endOf('day')
+         periods.push([start, end])
+      } else {
+         // Otherwise, pick the midnight of the first day of next month.
+         let end = moment(arg).utc().add(1, 'M')
+         periods.push([start, end])
+      }
     } else if (matchMonth.test(arg)) {
       let year = moment().year()
       const month = moment().month() + 1
@@ -72,7 +80,7 @@ function definePeriods () {
          let end = moment.utc().endOf('day')
          periods.push([start, end])
       } else {
-         // Otherwise, pick the first midnight of the first day of next month.
+         // Otherwise, pick the midnight of the first day of next month.
          let end = moment(yearAndMonth).utc().add(1, 'M')
          periods.push([start, end])
       }

--- a/lib/urcli-money.js
+++ b/lib/urcli-money.js
@@ -67,10 +67,9 @@ function definePeriods () {
       const yearAndMonth = arg < 9 ? `${year}-0${arg}` : `${year}-${arg}`
       let start = moment(yearAndMonth).utc()
       // Check if month asked is the current month
-      let currentMonth = moment.utc().add(1, 'M').month()
-      if (currentMonth == arg) {
+      if (arg === String(month)) {
          // Make the last day to query as being today
-         let end = moment.utc()
+         let end = moment.utc().endOf('day')
          periods.push([start, end])
       } else {
          // Otherwise, pick the first midnight of the first day of next month.
@@ -149,7 +148,7 @@ class Report {
   print () {
     let startDate = moment(this.period[0]).format('YYYY-MM-DD')
     let endDate = moment(this.period[1]).format('YYYY-MM-DD')
-    let numberDays = moment(endDate).diff(startDate, 'days')
+    let numberOfDays = moment(endDate).diff(startDate, 'days')
 
     console.log(chalk.blue(`\nEarnings Report for ${startDate} to ${endDate}:`))
     console.log('=============================================')
@@ -174,9 +173,9 @@ class Report {
 
     console.log(chalk.white(`Total Earned: ${currencyFormatter.format(this.totalEarned, {code: 'USD'})}`))
 
-    //Only print Daily Average if thea rgument is not 'today'
-    if (!(cli.args == 'today' || cli.args == 'yesterday')) {
-        console.log(chalk.white(`Daily Average: ${currencyFormatter.format(this.totalEarned/numberDays, {code: 'USD'})}`))
+    // Only print Daily Average if we have more than one day to average
+    if (numberOfDays > 1) {
+        console.log(chalk.white(`Daily Average: ${currencyFormatter.format(this.totalEarned/numberOfDays, {code: 'USD'})}`))
     }
     console.log('=============================================')
   }


### PR DESCRIPTION
This is a follow-up PR of #17.

There was one issue that was not addressed.

> Note that the Daily Average calculated for the overall report is not reliable since the initial date is 2014-01-01. I've tried to change this date to the first date where a project was completed but I was unsuccessful. How can I implement this?

I thought about two possible solutions:

* Obtain the first day that the reviewer started every time the money command was called without arguments. But I was having problems in implementing it. I could get the exact day, but I was unable to broadcast it to the calculation
* When doing the first setup, obtain the first day by identifying which was the reviewer's first certification and, then, get the certification date. This would be stored in the `.urcli_config.json` file, which could be used later.