### PR TITLE
Remove loop through PushBullet devices

### DIFF
--- a/lib/urcli-assign.js
+++ b/lib/urcli-assign.js
@@ -115,13 +115,11 @@ function assignmentNotification(projectInfo, submissionId) {
 
   // If the --push flag is set we push to active PushBullet devices
   if (cli.push) {
-    devices.forEach((deviceId) => {
-      pusher.note(deviceId, title, `${message}\n\n${open}`, (err) => {
-        if (err) {
-          console.error(err);
-          throw new Error('Failed to push to any active devices.');
-        }
-      });
+    pusher.note({}, title, `${message}\n\n${open}`, (err) => {
+      if (err) {
+        console.error(err);
+        throw new Error('Failed to push to any active devices.');
+      }
     });
   }
   notifier.notify({title, message, open, sound});

--- a/lib/urcli-assign.js
+++ b/lib/urcli-assign.js
@@ -115,7 +115,7 @@ function assignmentNotification(projectInfo, submissionId) {
 
   // If the --push flag is set we push to active PushBullet devices
   if (cli.push) {
-    pusher.note({}, title, `${message}\n\n${open}`, (err) => {
+    pusher.link({}, title, open, (err) => {
       if (err) {
         console.error(err);
         throw new Error('Failed to push to any active devices.');

--- a/lib/urcli-pushonce.js
+++ b/lib/urcli-pushonce.js
@@ -21,10 +21,8 @@ cli
       }
       console.log(res);
       // Save active devices.
-      res.devices.forEach((device) => {
-        pusher.note(device.iden, title, `${message}\n\n${open}`, (error) => {
-          if (error) throw new Error('Failed to push to any active devices.', error);
-        });
+      pusher.note({}, title, `${message}\n\n${open}`, (error) => {
+        if (error) throw new Error('Failed to push to any active devices.', error);
       });
       return res;
     });

--- a/lib/urcli-pushonce.js
+++ b/lib/urcli-pushonce.js
@@ -6,7 +6,6 @@ cli
   .arguments('<accessToken>')
   .action((accessToken) => {
     const title = 'Testnotification from urcli';
-    const message = 'This is a test!';
     const open = 'https://example.com';
     // Use PushBullet to notify all of the users active devices.
     const pusher = new PushBullet(accessToken);
@@ -21,7 +20,7 @@ cli
       }
       console.log(res);
       // Save active devices.
-      pusher.note({}, title, `${message}\n\n${open}`, (error) => {
+      pusher.link({}, title, open, (error) => {
         if (error) throw new Error('Failed to push to any active devices.', error);
       });
       return res;


### PR DESCRIPTION
By setting devices as an empty {} it will push to all devices. So, the
loops are also not needed.

This also avoid a strange behavior on the Chrome extension described in
issue #28 .

When merged, I think we can close #28 