### PR TITLE
Add hours of current day if month is current

### DIFF
--- a/src/commands/revenue.js
+++ b/src/commands/revenue.js
@@ -186,7 +186,7 @@ class Report {
       const month = moment(this.startDate).format('YYYY-MM');
       const isCurrentMonth = () => month === moment.utc().format('YYYY-MM');
       if (isCurrentMonth()) {
-        numberOfDays = moment.utc().diff(this.startDate, 'days', true);
+        numberOfDays = moment.utc().diff(moment.utc(this.startDate), 'days', true);
       }
       // Print Daily Average
       console.log(chalk.white(`Daily Average: ${

--- a/src/commands/revenue.js
+++ b/src/commands/revenue.js
@@ -179,8 +179,16 @@ class Report {
     console.log(chalk.white(`Total Earned: ${currencyFormatter.format(this.totalEarned, {code: 'USD'})}`));
 
     // Only print Daily Average if we have more than one day to average
-    const numberOfDays = moment(this.endDate).diff(this.startDate, 'days');
+    let numberOfDays = moment(this.endDate).diff(this.startDate, 'days');
+    // console.log(moment.utc().diff(this.startDate, 'days', true));
     if (numberOfDays > 1) {
+      // If current month, add hours of current day to numberOfDays
+      const month = moment(this.startDate).format('YYYY-MM');
+      const isCurrentMonth = () => month === moment.utc().format('YYYY-MM');
+      if (isCurrentMonth()) {
+        numberOfDays = moment.utc().diff(this.startDate, 'days', true);
+      }
+      // Print Daily Average
       console.log(chalk.white(`Daily Average: ${
         currencyFormatter.format(this.totalEarned / numberOfDays, {code: 'USD'})}`));
     }


### PR DESCRIPTION
When using the `money`command for the current month, the hours of the present day are not considered when calculating the Daily Average.

For example, right now is noon in UTC time. All the work a reviewer has done in this 12 hours counts when calculating the Daily Average, but the 12 hours are not being considered.

I've preferred to submit this as a PR instead of an issue because the implementation was quite simple and I had a lot of fun doing it. :smile: 