### PR TITLE
Add support for year.

### DIFF
--- a/src/commands/revenue.js
+++ b/src/commands/revenue.js
@@ -37,16 +37,17 @@ function definePeriods(args, options) {
   }
 
   function createYearPeriod(year) {
-    const start = moment(year, 'YYYY').utc();
+    const start = moment(year, 'YYYY');
     // If year is the current year the end should be today, otherwise it should be the end of the year.
-    const end = year === currentYear ? defaultEndTime : moment(year, 'YYYY').utc().endOf('year');
+    const end = year === currentYear ? defaultEndTime : moment(year, 'YYYY').endOf('year');
     periods.push([start, end]);
   }
 
   function createMonthPeriod(month) {
-    const start = moment(month).utc();
+    const start = moment(month);
     // If month is the current month the end should be today, otherwise it should be the end of the month.
-    const end = month === currentMonth ? defaultEndTime : moment(month).utc().add(1, 'M');
+    const end = month === currentMonth ? defaultEndTime : moment(month).add(1, 'M');
+    console.log([start, end]);
     periods.push([start, end]);
   }
 

--- a/src/commands/revenue.js
+++ b/src/commands/revenue.js
@@ -47,7 +47,6 @@ function definePeriods(args, options) {
     const start = moment(month);
     // If month is the current month the end should be today, otherwise it should be the end of the month.
     const end = month === currentMonth ? defaultEndTime : moment(month).add(1, 'M');
-    console.log([start, end]);
     periods.push([start, end]);
   }
 

--- a/src/commands/revenue.js
+++ b/src/commands/revenue.js
@@ -111,7 +111,7 @@ class Report {
     // find the earliest date a submission was assigned. This date is needed to
     // get the correct number of days of the period, so we can calculate the
     // average daily earnings for the period.
-    if (this.startDate === '2014-01-01') {
+    if (moment(this.startDate).format('DD') === '01') {
       const firstDate = reviews
         .map(review => moment(review.assigned_at)) // returns date of review
         .map(date => date.valueOf()) // returns date in Unix Time (milliseconds from 1970)


### PR DESCRIPTION
This change implements two modifications to `revenue`:

1. It adds support to year, e.g. `urcli revenue 2016`

2. Create an alias for current month and year. Each one can be accessed using `urcli revenue month/year`.

The motivation was that I am constantly using `revenue` to access my earning of the current month. And since there are aliases for today and yesterday, I thought that aliases for current month and year would be nice additions. 


### Update (2017-03-16)

This PR has changed its purpose and now it will only implement the support for year, e.g., `urcli revenue 2017`.