### PR TITLE
Revert PushBullet Notification

### DIFF
--- a/src/commands/assign.js
+++ b/src/commands/assign.js
@@ -216,7 +216,7 @@ function assignmentNotification(projectInfo, submissionId) {
   // If the --push flag is set we push to active PushBullet devices
   if (accessToken) {
     const pusher = new PushBullet(accessToken);
-    pusher.link({}, title, open, (err) => {
+    pusher.note({}, title, `${message}\n\n${open}`, (err) => {
       if (err) throw new Error(`Pushbullet error: ${err}`);
     });
   }


### PR DESCRIPTION
This revert to the old style of the PushBullet notification where the
project ID was shown.

The change was made on commit 8071eecc2c7c1c0672e85fee9d8424616a4ba4a9

When merged, close #49.
