### PR TITLE
Revenue fix

### DIFF
--- a/src/commands/revenue.js
+++ b/src/commands/revenue.js
@@ -8,6 +8,8 @@ import {api, config, formatPeriods, ReviewsStats} from '../utils';
 
 function print(report) {
   let output = `${chalk.blue(`\nEarnings Report for ${report.startDate} to ${report.endDate}:`)}\n`;
+  output += '=============================================\n';
+  output += (`Total Projects Assigned: ${report.totalAssigned}\n`);
 
   Object.keys(report.projects).forEach((key) => {
     const {name, id, ungradeable, passed, failed, earned, avgTurnaroundTime, totalAssigned} = report.projects[key];
@@ -22,6 +24,7 @@ function print(report) {
         Earned: ${currencyFormatter.format(earned, {code: 'USD'})}
         Average Turnaround Time: ${moment.utc(avgTurnaroundTime).format('HH:mm')}\n`;
   });
+
 
   const totalEarned = currencyFormatter.format(report.totalEarned, {code: 'USD'});
   output += `\nTotal Earned: ${totalEarned}\n`;

--- a/src/commands/revenue.js
+++ b/src/commands/revenue.js
@@ -20,7 +20,7 @@ function print(report) {
             Reviewed: ${passed + failed}
             Ungradeable: ${ungradeable}
         Earned: ${currencyFormatter.format(earned, {code: 'USD'})}
-        Average Turnaround Time: ${moment(avgTurnaroundTime).format('HH:mm')}\n`;
+        Average Turnaround Time: ${moment.utc(avgTurnaroundTime).format('HH:mm')}\n`;
   });
 
   const totalEarned = currencyFormatter.format(report.totalEarned, {code: 'USD'});

--- a/src/utils/ReviewsStats.js
+++ b/src/utils/ReviewsStats.js
@@ -20,13 +20,14 @@ export class ReviewsStats {
       // Set the average turnaround time for each project
       project.avgTurnaroundTime = project.totalTurnaroundTime / project.totalAssigned;
       // Find the average daily earnings
-      this.numberOfDays = moment.utc(this.endDate).diff(this.startDate, 'days');
+      // Increase 1 to account the last day, since it considers that `endDate` starts at 00:00
+      this.numberOfDays = moment(this.endDate).diff(this.startDate, 'days') + 1;
       const isCurrentMonth = (moment.utc(this.startDate).month() === moment.utc().month());
       if (isCurrentMonth) {
-        this.numberOfDays = moment.utc().diff(moment(this.startDate), 'days');
+        this.numberOfDays = moment.utc().diff(moment.utc(this.startDate), 'days', true);
       }
-      this.dailyAverage = this.numberOfDays ? project.earned / this.numberOfDays : project.earned;
     });
+    this.dailyAverage = this.numberOfDays ? this.totalEarned / this.numberOfDays : this.totalEarned;
   }
 
   countReview(review) {


### PR DESCRIPTION
Fix some issues in the `revenue` command.

* For previous months, the `numberOfDays` was off by one day. It is not an elegant fix. :sweat_smile: 
* For the current month, it was a UTC issue, and it was not considering the decimals.
* `dailyAverage` was being calculated for each project reviewed in a given month, but the variable was only storing in the last one.
