### PR TITLE
Hotfix on `revenue`

### DIFF
--- a/src/utils/ReviewsStats.js
+++ b/src/utils/ReviewsStats.js
@@ -19,14 +19,20 @@ export class ReviewsStats {
       const project = this.projects[id];
       // Set the average turnaround time for each project
       project.avgTurnaroundTime = project.totalTurnaroundTime / project.totalAssigned;
-      // Find the average daily earnings
+    });
+
+    // Find the average daily earnings
+
+    // Checks if the endTime is today or in the future. If yes it calculates
+    // the number of days considering the endDate as the current time. If not,
+    // it uses the endTime provided by the user.
+    const endIsToday = moment.utc().diff(this.endDate, 'days', true) < 1;
+    if (endIsToday) {
+      this.numberOfDays = moment.utc().diff(moment.utc(this.startDate), 'days', true);
+    } else {
       // Increase 1 to account the last day, since it considers that `endDate` starts at 00:00
       this.numberOfDays = moment(this.endDate).diff(this.startDate, 'days') + 1;
-      const isCurrentMonth = (moment.utc(this.startDate).month() === moment.utc().month());
-      if (isCurrentMonth) {
-        this.numberOfDays = moment.utc().diff(moment.utc(this.startDate), 'days', true);
-      }
-    });
+    }
     this.dailyAverage = this.numberOfDays ? this.totalEarned / this.numberOfDays : this.totalEarned;
   }
 

--- a/src/utils/ReviewsStats.js
+++ b/src/utils/ReviewsStats.js
@@ -23,10 +23,9 @@ export class ReviewsStats {
 
     // Find the average daily earnings
 
-    // Checks if the endTime is today or in the future. If yes it calculates
-    // the number of days considering the endDate as the current time. If not,
-    // it uses the endTime provided by the user.
-    const endIsToday = moment.utc().diff(this.endDate, 'days', true) < 1;
+    // Checks if the endTime is today. If yes, it calculate the number of days
+    // from startDate up to now.
+    const endIsToday = moment.utc().isSame(this.endDate, 'day');
     if (endIsToday) {
       this.numberOfDays = moment.utc().diff(moment.utc(this.startDate), 'days', true);
     } else {

--- a/src/utils/formatPeriods.js
+++ b/src/utils/formatPeriods.js
@@ -49,7 +49,7 @@ export function formatPeriods(args, cb) {
       end = month === currentMonth ? moment.utc() : moment.utc(month).endOf('month');
     } else if (matchYear.test(arg)) {
       start = moment.utc(arg, 'YYYY');
-      end = arg === moment.utc().year() ? moment.utc() : moment.utc(arg, 'YYYY').endOf('year');
+      end = arg === moment.utc().year().toString() ? moment.utc() : moment.utc(arg, 'YYYY').endOf('year');
     } else if (arg === 'week') {
       start = moment.utc().startOf('week');
       end = moment.utc().endOf('week');


### PR DESCRIPTION
This PR address:

* Daily average showing for `revenue today` and `yesterday`. Fix #81 
* Daily average and last day of the period was wrong when using `revenue current-year`. Fix #92 
