### PR TITLE
Displaying the submission_request_id

### DIFF
--- a/src/commands/assign/prompt.js
+++ b/src/commands/assign/prompt.js
@@ -49,6 +49,7 @@ const createProjectDetailsTable = () => {
           ]);
         });
       if (env.flags.infotext) {
+        output += `Current submission_request_id: ${env.submission_request.id}\n`;
         output += 'You are in the following queues:\n';
       }
       output += `${projectDetailsTable.toString()}\n\n`;


### PR DESCRIPTION
Hi Mikkel,

The Udacity Reviews team has been getting complaints from graders who say that their position in the queue is dropping from time to time, seemingly going from the front to the back.  We suspect that this is because their computers and going to sleep and their submission requests are not being refreshed, causing new ones to be created.

Displaying the submission_request_id along with the queue positions should help identify this situation and provide greater insight into any remaining bugs in the system.

Thanks for all of your great work on this!  urcli is a fantastic tool for our reviewers.

-CB

