### PR TITLE
Add ability to change base api url

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -4,7 +4,7 @@ import request from 'request';
 import {config} from './';
 
 function endpoint(task, id) {
-  const base = 'https://review-api.udacity.com/api/v1';
+  const base = process.env.UDACITY_API_BASE || 'https://review-api.udacity.com/api/v1';
   return {
     certifications: [`${base}/me/certifications/`, 'GET'],
     assigned: [`${base}/me/submissions/assigned/`, 'GET'],


### PR DESCRIPTION
Makes it possible to replace Udacity's reviews API base url with a url from an env var. Allows a user to potentially test against non-production versions of the reviews API.