### PR TITLE
Add a note about API being shut down

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CLI tool for the Udacity Reviews API
 
+**DISCLAIMER:** The API is going to be shut down and `urcli` will become inactive in the following months. We would like to thank all conributors and users for making `urcli` so awesome!
+
 `urcli` is a Command Line Interface for configuring and running API calls against the Udacity Reviews API. You can find the API documentation here: https://review.udacity.com/api-doc/index.html.
 
 [![npm downloads](https://img.shields.io/npm/dt/urcli.svg?style=flat)](https://www.npmjs.com/package/urcli)


### PR DESCRIPTION
I believe that, by adding a disclaimer notifying about the API shutdown, will let people know that `urcli` will stop work and avoid devs working on new features.
