### PR TITLE
Fix properly show max assignment message.

### DIFF
--- a/src/commands/assign/prompt.js
+++ b/src/commands/assign/prompt.js
@@ -34,7 +34,7 @@ const createProjectDetailsTable = () => {
     if (!env.positions.length) {
       console.log(env.positions);
       output += chalk.yellow('Waiting for queue information...\n\n');
-    } else if (env.assigned.length === 2) {
+    } else if (env.assigned.length === 5) {
       output += chalk.yellow(`You have ${chalk.white(env.assigned.length)} (max) submissions assigned.\n\n`);
     } else {
       projectDetailsTable.length = 0;


### PR DESCRIPTION
It was still limited to 2 submissions.

![selection_069](https://user-images.githubusercontent.com/2700254/36034479-58a061ea-0d9b-11e8-9ae9-33d7481218a8.png)

I've changed to appear it only when having 5 submissions. I have not tested it, but I think it will work.